### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -82,7 +82,7 @@ class syntax_plugin_mimetex extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
     */
-    function render($mode, &$renderer, $formula) {
+    function render($mode, Doku_Renderer $renderer, $formula) {
       global $conf;
       if( ($mode == 'xhtml' || $mode == 'odt') && strlen($formula[0]) > 1) {
         if ( !is_dir($conf['mediadir'] . '/latex') ) {


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
